### PR TITLE
System Permission Changes for Einstein Analytics Community User

### DIFF
--- a/force-app/main/default/permissionsets/Einstein_Analytics_Community_User.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Einstein_Analytics_Community_User.permissionset-meta.xml
@@ -2,4 +2,8 @@
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
     <hasActivationRequired>false</hasActivationRequired>
     <label>Einstein Analytics Community User</label>
+    <userPermissions>
+        <enabled>true</enabled>
+        <name>WaveCommunityUser</name>
+    </userPermissions>
 </PermissionSet>


### PR DESCRIPTION
# Critical Changes

# Changes
Setting "View Analytics on Communities pages" to true on the Einstein Analytics Community User Permission Set

# Issues Closed
