### PR TITLE
fix: remove references to non existent aura component

### DIFF
--- a/unpackaged/config/community/experiences/Traction_Thrive1/views/home.json
+++ b/unpackaged/config/community/experiences/Traction_Thrive1/views/home.json
@@ -23,25 +23,6 @@
       "renderPriority" : "NEUTRAL",
       "renditionMap" : { },
       "type" : "component"
-    }, {
-      "componentAttributes" : {
-        "iconColorBackground" : "#041d3e",
-        "iconName" : "standard:task",
-        "recordId" : "{!recordId}",
-        "showIcon" : true,
-        "showTitleBar" : true,
-        "statusBackground" : "#e4e4e4",
-        "statusColorAssigned" : "#041d3e",
-        "statusColorAvailable" : "#1390c6",
-        "statusColorNotAvailable" : "#f04d23",
-        "titleText" : "MY AVAILABILITY",
-        "titleTextForContactRecord" : "AVAILABILITY"
-      },
-      "componentName" : "c:staffAvailability",
-      "id" : "d4ecd98c-7498-4ea7-9804-35978d85cfe8",
-      "renderPriority" : "NEUTRAL",
-      "renditionMap" : { },
-      "type" : "component"
     } ],
     "id" : "514500d6-ee3e-4863-907c-cc2747dfcedc",
     "regionName" : "content",

--- a/unpackaged/config/community/experiences/Traction_Thrive1/views/staffDetail.json
+++ b/unpackaged/config/community/experiences/Traction_Thrive1/views/staffDetail.json
@@ -69,26 +69,7 @@
     "regionName" : "sfdcHiddenRegion",
     "type" : "region"
   }, {
-    "components" : [ {
-      "componentAttributes" : {
-        "iconColorBackground" : "#041d3e",
-        "iconName" : "standard:task",
-        "recordId" : "{!recordId}",
-        "showIcon" : true,
-        "showTitleBar" : true,
-        "statusBackground" : "#e4e4e4",
-        "statusColorAssigned" : "#041d3e",
-        "statusColorAvailable" : "#1390c6",
-        "statusColorNotAvailable" : "#f04d23",
-        "titleText" : "MY AVAILABILITY",
-        "titleTextForContactRecord" : "AVAILABILITY"
-      },
-      "componentName" : "c:staffAvailability",
-      "id" : "a2526768-e0f6-41ec-8d0a-dc68a3a32efb",
-      "renderPriority" : "NEUTRAL",
-      "renditionMap" : { },
-      "type" : "component"
-    } ],
+    "components" : [ ],
     "id" : "56e30524-1224-4935-8ff3-40b0b1c7e04e",
     "regionName" : "sidebar",
     "type" : "region"


### PR DESCRIPTION
Fixes deployment error

[Failed]: Update of ExperienceBundle Traction_Thrive1: Error: Implement 
"forceCommunity:availableForAllPageTypes" for the Aura component c:staffAvailability with ID a2526768-e0f6-41ec-8d0a-dc68a3a32efb and try again.


# Critical Changes

# Changes

# Issues Closed
