### PR TITLE
Changed the way we get profile name for test classes

### DIFF
--- a/force-app/main/default/classes/AccountPickerTest.cls
+++ b/force-app/main/default/classes/AccountPickerTest.cls
@@ -67,7 +67,7 @@ public with sharing class AccountPickerTest {
         testContact.AccountId = hospital.Id;
         insert testContact;
 
-        User communityUser = TestUtils.createCommunityUser(Constants.COMMUNITY_PROFILE_NAME, testContact.Id);
+        User communityUser = TestUtils.createCommunityUser(Constants.getCommunityProfileName(), testContact.Id);
 
         System.runAs(new User(Id = UserInfo.getUserId())) {
             insert communityUser;
@@ -76,7 +76,7 @@ public with sharing class AccountPickerTest {
 
     @IsTest
     static void getHealthAuthorities() {
-        User communityUser = [SELECT Id FROM User WHERE Profile.Name = :Constants.COMMUNITY_PROFILE_NAME ORDER BY CreatedDate DESC LIMIT 1];
+        User communityUser = [SELECT Id FROM User WHERE Profile.Name = :Constants.getCommunityProfileName() ORDER BY CreatedDate DESC LIMIT 1];
 
         List<Account> childHospitals;
         Test.startTest();
@@ -90,7 +90,7 @@ public with sharing class AccountPickerTest {
 
     @IsTest
     static void getChildAccounts() {
-        User communityUser = [SELECT Id, ContactId FROM User WHERE Profile.Name = :Constants.COMMUNITY_PROFILE_NAME ORDER BY CreatedDate DESC LIMIT 1];
+        User communityUser = [SELECT Id, ContactId FROM User WHERE Profile.Name = :Constants.getCommunityProfileName() ORDER BY CreatedDate DESC LIMIT 1];
         Account account = [SELECT Id, ParentId, Parent.ParentId FROM Account WHERE Name =: DIV_ACCOUNT_NAME AND RecordTypeId = :Constants.DIVISION_RECORDTYPE_ID LIMIT 1];
         Account hosp2 = [SELECT Id, ParentId, Parent.ParentId FROM Account WHERE Name =: HOSP_ACCOUNT_NAME + '2' AND RecordTypeId = :Constants.HOSPITAL_RECORDTYPE_ID LIMIT 1];
 
@@ -111,7 +111,7 @@ public with sharing class AccountPickerTest {
 
     @IsTest
     static void getAccountSelectionHospitalUser() {
-        User communityUser = [SELECT Id, ContactId FROM User WHERE Profile.Name = :Constants.COMMUNITY_PROFILE_NAME ORDER BY CreatedDate DESC LIMIT 1];
+        User communityUser = [SELECT Id, ContactId FROM User WHERE Profile.Name = :Constants.getCommunityProfileName() ORDER BY CreatedDate DESC LIMIT 1];
         Account account = [SELECT Id, ParentId, Parent.ParentId FROM Account WHERE Name =: DIV_ACCOUNT_NAME AND RecordTypeId = :Constants.DIVISION_RECORDTYPE_ID LIMIT 1];
         Account hosp2 = [SELECT Id, ParentId, Parent.ParentId FROM Account WHERE Name =: DIV_ACCOUNT_NAME + '2' AND RecordTypeId = :Constants.DIVISION_RECORDTYPE_ID LIMIT 1];
 

--- a/force-app/main/default/classes/AllResourceTest.cls
+++ b/force-app/main/default/classes/AllResourceTest.cls
@@ -49,7 +49,7 @@ private with sharing class AllResourceTest {
         testContact.AccountId = division.Id;
         insert testContact;
 
-        User communityUser = TestUtils.createCommunityUser(Constants.COMMUNITY_PROFILE_NAME, testContact.Id);
+        User communityUser = TestUtils.createCommunityUser(Constants.getCommunityProfileName(), testContact.Id);
 
         System.runAs(new User(Id = UserInfo.getUserId())) {
             insert communityUser;
@@ -58,7 +58,7 @@ private with sharing class AllResourceTest {
 
     @IsTest
     static void getContactInfo() {
-        User communityUser = [SELECT Id FROM User WHERE Profile.Name = :Constants.COMMUNITY_PROFILE_NAME ORDER BY CreatedDate DESC LIMIT 1];
+        User communityUser = [SELECT Id FROM User WHERE Profile.Name = :Constants.getCommunityProfileName() ORDER BY CreatedDate DESC LIMIT 1];
 
         User currentUser;
         Test.startTest();
@@ -68,6 +68,6 @@ private with sharing class AllResourceTest {
         Test.stopTest();
 
         System.assertEquals(communityUser.Id, currentUser.Id, 'Expected current user to be returned');
-        System.assertEquals(Constants.COMMUNITY_PROFILE_NAME, currentUser.Profile.Name, 'Expected correct profile to be returned');
+        System.assertEquals(Constants.getCommunityProfileName(), currentUser.Profile.Name, 'Expected correct profile to be returned');
     }
 }

--- a/force-app/main/default/classes/AppUtilsTest.cls
+++ b/force-app/main/default/classes/AppUtilsTest.cls
@@ -44,7 +44,7 @@ public with sharing class AppUtilsTest {
 		testContact.AccountId = account.Id;
 		insert testContact;
 
-		communityUser = TestUtils.createCommunityUser(Constants.COMMUNITY_PROFILE_NAME, testContact.Id);
+		communityUser = TestUtils.createCommunityUser(Constants.getCommunityProfileName(), testContact.Id);
 
 		System.runAs(new User(Id = UserInfo.getUserId())){
 			insert communityUser;

--- a/force-app/main/default/classes/Constants.cls
+++ b/force-app/main/default/classes/Constants.cls
@@ -38,18 +38,20 @@ public with sharing class Constants {
     public final static Id HEALTH_AUTH_RECORDTYPE_ID = Account.SObjectType.getDescribe().getRecordTypeInfosByDeveloperName().get('Regional_Health_Authority').recordTypeId;
     public final static Id HOSPITAL_RECORDTYPE_ID = Account.SObjectType.getDescribe().getRecordTypeInfosByDeveloperName().get('Hospital').recordTypeId;
     public final static Id DIVISION_RECORDTYPE_ID = Account.SObjectType.getDescribe().getRecordTypeInfosByDeveloperName().get('Division').recordTypeId;
-
-    //Profile
-    public final static String COMMUNITY_PROFILE_NAME = [
-            SELECT Id, Name, UserLicense.Name
-            FROM Profile
-            WHERE UserLicense.Name = 'Customer Community Login' AND Name LIKE '%Admin%'
-            LIMIT 1
-    ].Name;
-
+    
     //Availability
     public final static String AVAILABLE_ASSIGNMENT_STATUS = 'Available';
     public final static String NOT_AVAILABLE_ASSIGNMENT_STATUS = 'Not Available';
+
+    //Community Profile
+    public static String getCommunityProfileName() {
+        return [
+                SELECT Id, Name, UserLicense.Name
+                FROM Profile
+                WHERE UserLicense.Name = 'Customer Community Login' AND Name LIKE '%Admin%'
+                LIMIT 1
+        ].Name;
+    }
 
     //Status Report Categories
     public static Map<String, String> getStatusReportTypeMapping() {

--- a/force-app/main/default/classes/ConstantsTest.cls
+++ b/force-app/main/default/classes/ConstantsTest.cls
@@ -46,7 +46,7 @@ public with sharing class ConstantsTest {
 		contact.AccountId = account.Id;
 		insert contact;
 
-		communityUser = TestUtils.createCommunityUser(Constants.COMMUNITY_PROFILE_NAME, contact.Id);
+		communityUser = TestUtils.createCommunityUser(Constants.getCommunityProfileName(), contact.Id);
 
 		System.runAs(new User(Id = UserInfo.getUserId())){
 			insert communityUser;

--- a/force-app/main/default/classes/ContactCardCtrlTest.cls
+++ b/force-app/main/default/classes/ContactCardCtrlTest.cls
@@ -42,7 +42,7 @@ public with sharing class ContactCardCtrlTest {
         testContact.AccountId = account.Id;
         insert testContact;
 
-        User communityUser = TestUtils.createCommunityUser(Constants.COMMUNITY_PROFILE_NAME, testContact.Id);
+        User communityUser = TestUtils.createCommunityUser(Constants.getCommunityProfileName(), testContact.Id);
 
         System.runAs(new User(Id = UserInfo.getUserId())){
             insert communityUser;

--- a/force-app/main/default/classes/ContactEditFormControllerTest.cls
+++ b/force-app/main/default/classes/ContactEditFormControllerTest.cls
@@ -54,7 +54,7 @@ public with sharing class ContactEditFormControllerTest {
 
 		insert credentials;
 
-		communityUser = TestUtils.createCommunityUser(Constants.COMMUNITY_PROFILE_NAME, contact.Id);
+		communityUser = TestUtils.createCommunityUser(Constants.getCommunityProfileName(), contact.Id);
 		//insert user;
 
 		System.runAs(new User(Id = UserInfo.getUserId())){

--- a/force-app/main/default/classes/CredentialsSelectorTest.cls
+++ b/force-app/main/default/classes/CredentialsSelectorTest.cls
@@ -54,7 +54,7 @@ public with sharing class CredentialsSelectorTest {
 
 		insert credentials;
 
-		communityUser = TestUtils.createCommunityUser(Constants.COMMUNITY_PROFILE_NAME, contact.Id);
+		communityUser = TestUtils.createCommunityUser(Constants.getCommunityProfileName(), contact.Id);
 		//insert user;
 
 		System.runAs(new User(Id = UserInfo.getUserId())){

--- a/force-app/main/default/classes/ResourceStatusTrackerTest.cls
+++ b/force-app/main/default/classes/ResourceStatusTrackerTest.cls
@@ -58,7 +58,7 @@ private class ResourceStatusTrackerTest {
         testContact.AccountId = hospital.Id;
         insert testContact;
 
-        User communityUser = TestUtils.createCommunityUser(Constants.COMMUNITY_PROFILE_NAME, testContact.Id);
+        User communityUser = TestUtils.createCommunityUser(Constants.getCommunityProfileName(), testContact.Id);
 
         System.runAs(new User(Id = UserInfo.getUserId())){
             insert communityUser;
@@ -81,7 +81,7 @@ private class ResourceStatusTrackerTest {
 
     @IsTest
     static void getResourceCount() {
-        User testUsr = [SELECT Id, Contact.AccountId FROM User WHERE Profile.Name = :Constants.COMMUNITY_PROFILE_NAME ORDER BY CreatedDate DESC LIMIT 1];
+        User testUsr = [SELECT Id, Contact.AccountId FROM User WHERE Profile.Name = :Constants.getCommunityProfileName() ORDER BY CreatedDate DESC LIMIT 1];
         Account department = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.DIVISION_RECORDTYPE_ID ORDER BY CreatedDate DESC];
 
         Status_Report__c statusReport;
@@ -97,7 +97,7 @@ private class ResourceStatusTrackerTest {
 
     @IsTest
     static void setResourceCount() {
-        User testUsr = [SELECT Id, Contact.AccountId FROM User WHERE Profile.Name = :Constants.COMMUNITY_PROFILE_NAME ORDER BY CreatedDate DESC LIMIT 1];
+        User testUsr = [SELECT Id, Contact.AccountId FROM User WHERE Profile.Name = :Constants.getCommunityProfileName() ORDER BY CreatedDate DESC LIMIT 1];
         Account department = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.DIVISION_RECORDTYPE_ID ORDER BY CreatedDate DESC];
 
         Test.startTest();

--- a/force-app/main/default/classes/StaffAssignmentControllerTest.cls
+++ b/force-app/main/default/classes/StaffAssignmentControllerTest.cls
@@ -50,7 +50,7 @@ private class StaffAssignmentControllerTest {
         contact2 = TestUtils.createCommunityContact('Test', false);
         contact2.AccountId = account.Id;
         insert contact2;
-        user = TestUtils.createCommunityUser(Constants.COMMUNITY_PROFILE_NAME, contact1.Id);
+        user = TestUtils.createCommunityUser(Constants.getCommunityProfileName(), contact1.Id);
         insert user;
         }
 

--- a/force-app/main/default/classes/StaffAssignmentServiceTest.cls
+++ b/force-app/main/default/classes/StaffAssignmentServiceTest.cls
@@ -46,7 +46,7 @@ public with sharing class StaffAssignmentServiceTest {
 		contact.AccountId = account.Id;
 		insert contact;
 
-		communityUser = TestUtils.createCommunityUser(Constants.COMMUNITY_PROFILE_NAME, contact.Id);
+		communityUser = TestUtils.createCommunityUser(Constants.getCommunityProfileName(), contact.Id);
 
 		System.runAs(new User(Id = UserInfo.getUserId())){
 			insert communityUser;

--- a/force-app/main/default/classes/StatusReportSelectorTest.cls
+++ b/force-app/main/default/classes/StatusReportSelectorTest.cls
@@ -36,7 +36,7 @@
 public with sharing class StatusReportSelectorTest {
 	private final static String resourceType = Status_Report__c.Type__c.getDescribe().getPicklistValues()[0].value;
 	private final static String resourceStatus = Status_Report__c.Status__c.getDescribe().getPicklistValues()[0].value;
-	private final static String PROFILE_NAME = Constants.COMMUNITY_PROFILE_NAME;
+	private final static String PROFILE_NAME = Constants.getCommunityProfileName();
 
 	@TestSetup
 	static void setup() {

--- a/force-app/main/default/classes/StatusReportStatusPicklistTest.cls
+++ b/force-app/main/default/classes/StatusReportStatusPicklistTest.cls
@@ -35,7 +35,7 @@
 @IsTest
 private class StatusReportStatusPicklistTest {
 
-    private final static String PROFILE_NAME = Constants.COMMUNITY_PROFILE_NAME;
+    private final static String PROFILE_NAME = Constants.getCommunityProfileName();
 
     @TestSetup
     static void setup() {

--- a/force-app/main/default/classes/StatusReportTypePicklistTest.cls
+++ b/force-app/main/default/classes/StatusReportTypePicklistTest.cls
@@ -35,7 +35,7 @@
 @IsTest
 private class StatusReportTypePicklistTest {
 
-    private final static String PROFILE_NAME = Constants.COMMUNITY_PROFILE_NAME;
+    private final static String PROFILE_NAME = Constants.getCommunityProfileName();
 
     @TestSetup
     static void setup() {


### PR DESCRIPTION
A query was being called everytime we were calling the constants class. Created a method for that instead of using a query as a variable



# Critical Changes

# Changes

# Issues Closed
