### PR TITLE
traction-333 Update metadeploy installer to show Configure Community 

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -445,6 +445,7 @@ plans:
                 flow: config_community
                 options:
                     deploy_community_config:
+                        name: "Configure Community"
                         unmanaged: False
                         is_required: False
                 ui_options:


### PR DESCRIPTION
# Critical Changes

# Changes

- show "Configure Community" on installer page instead of "deploy_community_config"

# Issues Closed
