### PR TITLE
Updated the Facility Record Page and the Staff Compact Layout.

### DIFF
--- a/force-app/main/default/flexipages/Facility_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Facility_Record_Page.flexipage-meta.xml
@@ -55,6 +55,10 @@
     <flexiPageRegions>
         <componentInstances>
             <componentInstanceProperties>
+                <name>active</name>
+                <value>true</value>
+            </componentInstanceProperties>
+            <componentInstanceProperties>
                 <name>body</name>
                 <value>Facet-b37528c4-fc66-4bcc-aaab-adf31288ccae</value>
             </componentInstanceProperties>
@@ -67,7 +71,7 @@
         <componentInstances>
             <componentInstanceProperties>
                 <name>active</name>
-                <value>true</value>
+                <value>false</value>
             </componentInstanceProperties>
             <componentInstanceProperties>
                 <name>body</name>
@@ -94,6 +98,36 @@
         <type>Region</type>
     </flexiPageRegions>
     <flexiPageRegions>
+        <componentInstances>
+            <componentInstanceProperties>
+                <name>parentFieldApiName</name>
+                <value>Account.Id</value>
+            </componentInstanceProperties>
+            <componentInstanceProperties>
+                <name>relatedListApiName</name>
+                <value>Staff_Level__r</value>
+            </componentInstanceProperties>
+            <componentInstanceProperties>
+                <name>relatedListComponentOverride</name>
+                <value>NONE</value>
+            </componentInstanceProperties>
+            <componentInstanceProperties>
+                <name>rowsToDisplay</name>
+                <value>10</value>
+            </componentInstanceProperties>
+            <componentInstanceProperties>
+                <name>showActionBar</name>
+                <value>true</value>
+            </componentInstanceProperties>
+            <componentName>force:relatedListSingleContainer</componentName>
+            <visibilityRule>
+                <criteria>
+                    <leftValue>{!Record.RecordType.Name}</leftValue>
+                    <operator>EQUAL</operator>
+                    <rightValue>Division</rightValue>
+                </criteria>
+            </visibilityRule>
+        </componentInstances>
         <componentInstances>
             <componentInstanceProperties>
                 <name>parentFieldApiName</name>

--- a/force-app/main/default/objects/Contact/compactLayouts/Traction_Thrive_Staff_Layout.compactLayout-meta.xml
+++ b/force-app/main/default/objects/Contact/compactLayouts/Traction_Thrive_Staff_Layout.compactLayout-meta.xml
@@ -4,6 +4,7 @@
     <fields>Name</fields>
     <fields>AccountId</fields>
     <fields>Phone</fields>
+    <fields>Role_Global__c</fields>
     <fields>Status__c</fields>
     <label>Traction Thrive Staff Layout</label>
 </CompactLayout>


### PR DESCRIPTION
Part of Release 1.7

# Critical Changes

# Changes
- The Tab: Details is the default selected tab on the Facility Page.
- The Related List: Staff Levels can also be seen on the right side of the Facility Page but for Division Accounts only.
- The Staff Compact Layout shall contain the following fields: Name, Account Name, Phone, Role, and Status.

# Issues Closed
