### PR TITLE
TRACTION-312 | Set Knowledge Default Record Type to "FAQ" for System Admin Profile

### DIFF
--- a/unpackaged/config/profiles/profiles/Admin.profile
+++ b/unpackaged/config/profiles/profiles/Admin.profile
@@ -583,6 +583,17 @@
         <recordType>Account.%%%NAMESPACE%%%Regional_Health_Authority</recordType>
         <visible>true</visible>
     </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <default>true</default>
+        <personAccountDefault>true</personAccountDefault>
+        <recordType>Knowledge__kav.FAQ</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
+    <recordTypeVisibilities>
+        <default>false</default>
+        <recordType>Knowledge__kav.Procedure</recordType>
+        <visible>true</visible>
+    </recordTypeVisibilities>
     <tabVisibilities>
         <tab>%%%NAMESPACE%%%About_Us</tab>
         <visibility>DefaultOn</visibility>


### PR DESCRIPTION
Part of Release 1.7

# Critical Changes

# Changes
- Updated the Profile: System Administrator with the following changes:
-- Knowledge Default Record Type is set to "FAQ"
-- Added access to the Knowledge Record Type: Procedure

# Issues Closed
