### PR TITLE
R1.9, TRACTION-434 | Added trigger on facility to stamp name

### DIFF
--- a/force-app/main/default/classes/AccountHandler.cls
+++ b/force-app/main/default/classes/AccountHandler.cls
@@ -1,0 +1,36 @@
+/**
+ * @description Handler class for account records
+ * @author  Heather Purvis, Traction on Demand
+ * @date    2020-05-12
+ */
+public with sharing class AccountHandler {
+
+    /**
+     * @description Stamps Health Authority Name on insert of a facility to the Health Authority field
+     * @param       newAccounts Newly inserted accounts
+     */
+    public void handleStampingHealthAuthorityOnFacility(List<Account> newAccounts) {
+        Set<Id> parentAccountIds = new Set<Id>();
+
+        for (Account account : newAccounts) {
+            parentAccountIds.add(account.ParentId);
+        }
+
+        Map<Id, Account> parentAccountsByIds = new Map<Id, Account>(AccountsSelector.getAccountHierarchyAccounts(parentAccountIds));
+        for (Account account : newAccounts) {
+            if (account.RecordTypeId == Constants.HOSPITAL_RECORDTYPE_ID) {
+                if (account.ParentId != null && parentAccountsByIds.containsKey(account.ParentId)) {
+                    account.Health_Authority__c = parentAccountsByIds.get(account.ParentId).Name;
+                }
+            } else if (account.RecordTypeId == Constants.DIVISION_RECORDTYPE_ID) {
+                if (account.ParentId != null
+                        && parentAccountsByIds.containsKey(account.ParentId)
+                        && parentAccountsByIds.get(account.ParentId).ParentId != null) {
+                    account.Health_Authority__c = parentAccountsByIds.get(account.ParentId).Parent.Name;
+                }
+            } else {
+                account.Health_Authority__c = account.Name;
+            }
+        }
+    }
+}

--- a/force-app/main/default/classes/AccountHandler.cls-meta.xml
+++ b/force-app/main/default/classes/AccountHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>45.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountHandlerTest.cls
+++ b/force-app/main/default/classes/AccountHandlerTest.cls
@@ -1,0 +1,29 @@
+/**
+ * @description Test class for AccountHandler
+ * @author  Heather Purvis, Traction on Demand
+ * @date    2020-05-12
+ */
+@IsTest
+public with sharing class AccountHandlerTest {
+
+    private final static String HA_ACCOUNT_NAME = 'Test AHT health auth';
+
+    @IsTest
+    static void accountHealthAuthNameUpdate(){
+        String name = HA_ACCOUNT_NAME;
+
+        Test.startTest();
+        Account healthAuth = TestUtils.createAccountByRecordType(name, Constants.HEALTH_AUTH_RECORDTYPE_ID, null, true);
+        Account hospital = TestUtils.createAccountByRecordType('hospital', Constants.HOSPITAL_RECORDTYPE_ID, healthAuth.Id, true);
+        Account division = TestUtils.createAccountByRecordType('division', Constants.DIVISION_RECORDTYPE_ID, hospital.Id, true);
+        Test.stopTest();
+
+        healthAuth = [SELECT ID, Health_Authority__c FROM Account WHERE Id = :healthAuth.Id];
+        hospital = [SELECT ID, Health_Authority__c FROM Account WHERE Id = :hospital.Id];
+        division = [SELECT ID, Health_Authority__c FROM Account WHERE Id = :division.Id];
+
+        System.assertEquals(name, healthAuth.Health_Authority__c, 'Expected health auth name to be stamped');
+        System.assertEquals(name, hospital.Health_Authority__c, 'Expected health auth name to be stamped');
+        System.assertEquals(name, division.Health_Authority__c, 'Expected health auth name to be stamped');
+    }
+}

--- a/force-app/main/default/classes/AccountHandlerTest.cls-meta.xml
+++ b/force-app/main/default/classes/AccountHandlerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>45.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountService.cls
+++ b/force-app/main/default/classes/AccountService.cls
@@ -1,0 +1,44 @@
+/*
+    Copyright (c) 2020, Traction Sales And Marketing Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this List of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this List of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author  Heather Purvis, Traction on Demand
+ * @date    2020-05-12
+ */
+public with sharing class AccountService {
+
+    /**
+     * @description Before insert trigger logic
+     * @param       newAccountList newly inserted accounts
+     */
+    public static void onBeforeInsertUpdate(List<Account> newAccountList) {
+        AccountHandler accountHandler = new AccountHandler();
+        accountHandler.handleStampingHealthAuthorityOnFacility(newAccountList);
+    }
+}

--- a/force-app/main/default/classes/AccountService.cls-meta.xml
+++ b/force-app/main/default/classes/AccountService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>45.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountsSelector.cls
+++ b/force-app/main/default/classes/AccountsSelector.cls
@@ -120,4 +120,27 @@ public with sharing class AccountsSelector {
         ];
         return accounts;
     }
+
+    /**
+     * @description Given a set of account ids returns the info of the hierarchy
+     * @param       accountIds
+     * @return      List of accounts
+     */
+    public static List<Account> getAccountHierarchyAccounts(Set<Id> accountIds) {
+        List<Account> accounts = [
+                SELECT  Id,
+                        Name,
+                        Health_Authority__c,
+                        ParentId,
+                        Parent.Name,
+                        Parent.Health_Authority__c,
+                        Parent.ParentId,
+                        Parent.Parent.Name,
+                        Parent.Parent.Health_Authority__c,
+                        RecordTypeId
+                FROM    Account
+                WHERE   Id IN :accountIds
+        ];
+        return accounts;
+    }
 }

--- a/force-app/main/default/classes/TestUtils.cls
+++ b/force-app/main/default/classes/TestUtils.cls
@@ -91,8 +91,7 @@ public class TestUtils {
                 Name = name,
                 RecordTypeId = RecordTypeId,
                 ParentId = parentId,
-                BillingState = 'BC',
-                Health_Authority__c = name
+                BillingState = 'BC'
         );
 
         if(doInsert){

--- a/force-app/main/default/triggers/AccountTrigger.trigger
+++ b/force-app/main/default/triggers/AccountTrigger.trigger
@@ -1,0 +1,39 @@
+/*
+    Copyright (c) 2020, Traction Sales And Marketing Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this List of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this List of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author  Heather Purvis, Traction on Demand
+ * @date    2020-05-12
+ */
+trigger AccountTrigger on Account (before insert, before update, before delete, after insert, after update, after delete, after undelete) {
+
+    if (Trigger.isBefore && (Trigger.isInsert || Trigger.isUpdate)) {
+        AccountService.onBeforeInsertUpdate(Trigger.new);
+    }
+}

--- a/force-app/main/default/triggers/AccountTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/AccountTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
Health authority name stamped in Health_Authority__c field before insert of facility

# Critical Changes

# Changes

- Trigger on Before insert of Facility to stamp a field with parent Health Authority Name

# Issues Closed
