### PR TITLE
R1.9, TRACTION-425 | Duplicate Rule: Block users from creating duplicate Staff Access records.

### DIFF
--- a/force-app/main/default/objects/Staff_Access__c/fields/Staff_Record_ID__c.field-meta.xml
+++ b/force-app/main/default/objects/Staff_Access__c/fields/Staff_Record_ID__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Staff_Record_ID__c</fullName>
+    <description>Returns the record ID of the related Staff record. Used in a matching rule. Not meant to be on the page layout.</description>
+    <externalId>false</externalId>
+    <label>Staff Record ID</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/unpackaged/post/configuration/duplicateRules/___NAMESPACE___Staff_Access__c.Staff_Access_Duplicate_Rule.duplicateRule
+++ b/unpackaged/post/configuration/duplicateRules/___NAMESPACE___Staff_Access__c.Staff_Access_Duplicate_Rule.duplicateRule
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DuplicateRule xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <actionOnInsert>Block</actionOnInsert>
+    <actionOnUpdate>Block</actionOnUpdate>
+    <alertText>An existing Staff Access record already exists with this Staff Member for this Care Facility.</alertText>
+    <description>Blocks users from creating duplicate Staff Access records.</description>
+    <duplicateRuleFilter xsi:nil="true"/>
+    <duplicateRuleMatchRules>
+        <matchRuleSObjectType>%%%NAMESPACE%%%Staff_Access__c</matchRuleSObjectType>
+        <matchingRule>Staff_Access_Matching_Rule</matchingRule>
+        <objectMapping xsi:nil="true"/>
+    </duplicateRuleMatchRules>
+    <isActive>true</isActive>
+    <masterLabel>Staff Access Duplicate Rule</masterLabel>
+    <securityOption>BypassSharingRules</securityOption>
+    <sortOrder>1</sortOrder>
+</DuplicateRule>

--- a/unpackaged/post/configuration/matchingRules/___NAMESPACE___Staff_Access__c.matchingRule
+++ b/unpackaged/post/configuration/matchingRules/___NAMESPACE___Staff_Access__c.matchingRule
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MatchingRules xmlns="http://soap.sforce.com/2006/04/metadata">
+    <matchingRules>
+        <fullName>Staff_Access_Matching_Rule</fullName>
+        <description>Matches the Staff Record ID and Care Facility of Staff Access records.</description>
+        <label>Staff Access Matching Rule</label>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>%%%NAMESPACE%%%Care_Facility__c</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>%%%NAMESPACE%%%Staff_Record_ID__c</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <ruleStatus>Active</ruleStatus>
+    </matchingRules>
+</MatchingRules>


### PR DESCRIPTION
You might need to merge feature/TRACTION-427 first before you can merge this one...

# Critical Changes

# Changes
- Created a Duplicate Rule for the Staff Access object.

# Issues Closed
