### PR TITLE
R1.9 TRACTION-426 | Validation Rule: Block users from modifying existing Staff Access records.

### DIFF
--- a/force-app/main/default/layouts/Staff_Access__c-Staff Access Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Staff_Access__c-Staff Access Layout.layout-meta.xml
@@ -20,7 +20,12 @@
                 <field>Staff__c</field>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns/>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Access_Level__c</field>
+            </layoutItems>
+        </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>
     <layoutSections>
@@ -58,7 +63,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h55000000xob3</masterLabel>
+        <masterLabel>00h8A000001CetF</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/objects/Staff_Access__c/fields/Access_Level__c.field-meta.xml
+++ b/force-app/main/default/objects/Staff_Access__c/fields/Access_Level__c.field-meta.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Access_Level__c</fullName>
+    <description>Determines the type of access a Staff has to a Facility.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Determines the type of access a Staff has to a Facility.</inlineHelpText>
+    <label>Access Level</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Read</fullName>
+                <default>false</default>
+                <label>Read</label>
+            </value>
+            <value>
+                <fullName>Edit</fullName>
+                <default>false</default>
+                <label>Edit</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/Staff_Access__c/validationRules/Block_edits_to_Staff_Access_Fields.validationRule-meta.xml
+++ b/force-app/main/default/objects/Staff_Access__c/validationRules/Block_edits_to_Staff_Access_Fields.validationRule-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Block_edits_to_Staff_Access_Fields</fullName>
+    <active>true</active>
+    <description>Blocks users from editing the following Staff Access fields: Staff, Facility and Access Level.</description>
+    <errorConditionFormula>ISCHANGED( Care_Facility__c )  || 
+ISCHANGED( Staff__c ) ||
+ISCHANGED( Access_Level__c )</errorConditionFormula>
+    <errorMessage>Unable to edit existing Staff Access. Please delete the current record and create a new Staff Access.</errorMessage>
+</ValidationRule>

--- a/unpackaged/config/profiles/profiles/Admin.profile
+++ b/unpackaged/config/profiles/profiles/Admin.profile
@@ -406,6 +406,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Access_Level__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Division__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/unpackaged/config/profiles/profiles/Customer Community - Health Authority.profile
+++ b/unpackaged/config/profiles/profiles/Customer Community - Health Authority.profile
@@ -419,6 +419,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Access_Level__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Division__c</field>
         <readable>true</readable>

--- a/unpackaged/config/profiles/profiles/Customer Community - Hospital Administrator.profile
+++ b/unpackaged/config/profiles/profiles/Customer Community - Hospital Administrator.profile
@@ -419,6 +419,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Access_Level__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Division__c</field>
         <readable>true</readable>

--- a/unpackaged/config/profiles/profiles/Customer Community - Medical Staff.profile
+++ b/unpackaged/config/profiles/profiles/Customer Community - Medical Staff.profile
@@ -419,6 +419,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Access_Level__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Division__c</field>
         <readable>true</readable>

--- a/unpackaged/config/profiles/profiles/Customer Community Plus - Health Authority.profile
+++ b/unpackaged/config/profiles/profiles/Customer Community Plus - Health Authority.profile
@@ -419,6 +419,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Access_Level__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Division__c</field>
         <readable>true</readable>

--- a/unpackaged/config/profiles/profiles/Customer Community Plus - Hospital Administrator.profile
+++ b/unpackaged/config/profiles/profiles/Customer Community Plus - Hospital Administrator.profile
@@ -419,6 +419,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Access_Level__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Division__c</field>
         <readable>true</readable>

--- a/unpackaged/config/profiles/profiles/Customer Community Plus - Medical Staff.profile
+++ b/unpackaged/config/profiles/profiles/Customer Community Plus - Medical Staff.profile
@@ -419,6 +419,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Access_Level__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>%%%NAMESPACE%%%Staff_Access__c.%%%NAMESPACE%%%Division__c</field>
         <readable>true</readable>


### PR DESCRIPTION
# Critical Changes

# Changes
- Created a new Staff Access Field: Access Level.
- Added the new field to the Staff Access Layout.
- Added field permissions for the new field to the Admin and all Community profiles.
- Created a new Staf Access Validation Rule.

# Issues Closed
