### PR TITLE
R1.9 TRACTION-432 | Validation Rule | Contacts cannot change care facility

### DIFF
--- a/force-app/main/default/objects/Contact/validationRules/Blocks_changes_to_Primary_Facility.validationRule-meta.xml
+++ b/force-app/main/default/objects/Contact/validationRules/Blocks_changes_to_Primary_Facility.validationRule-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Blocks_changes_to_Primary_Facility</fullName>
+    <active>true</active>
+    <description>Blocks users from changing an existing Staff record&#39;s Primary Facility.</description>
+    <errorConditionFormula>ISCHANGED( AccountId )</errorConditionFormula>
+    <errorMessage>Unable to change the Primary Facility. Please generate a new Contact record for this user with the new Facility, or use Staff Access to give this user access to other Facilities.</errorMessage>
+</ValidationRule>


### PR DESCRIPTION

# Critical Changes

# Changes
- Created a new Contact Validation Rule that blocks users from editing the Facility directly associated with a Contact record.

# Issues Closed
