### PR TITLE
R1.9 TRACTION 429 | Added staff access trigger to stamp id

### DIFF
--- a/force-app/main/default/classes/Constants.cls
+++ b/force-app/main/default/classes/Constants.cls
@@ -53,6 +53,9 @@ public with sharing class Constants {
         ].Name;
     }
 
+    //Access level
+    public final static String READ_ACCESS = 'Read';
+    public final static String EDIT_ACCESS = 'Edit';
     //Status Report Categories
     public static Map<String, String> getStatusReportTypeMapping() {
         Status_Report_Type_Mapping__mdt[] mappings = [
@@ -78,8 +81,5 @@ public with sharing class Constants {
     public final static String NOT_AVAILABLE_STATUS = 'Not Available';
     public final static String AVAILABLE_STATUS = 'On staff';
 
-    //Access level
-    public final static String READ_ACCESS = 'Read';
-    public final static String EDIT_ACCESS = 'Edit';
 
 }

--- a/force-app/main/default/classes/StaffAccessHandler.cls
+++ b/force-app/main/default/classes/StaffAccessHandler.cls
@@ -1,0 +1,62 @@
+/*
+    Copyright (c) 2020, Traction Sales And Marketing Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this List of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this List of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author  Heather Purvis, Traction on Demand
+ * @date    2020-05-13
+ */
+public with sharing class StaffAccessHandler {
+
+    private List<Staff_Access__c> access;
+    private Map<Id, Staff_Access__c> oldAccess;
+
+    /**
+    * @description          Constructor
+    *
+    * @param access     [Trigger.new access]
+    * @param oldAccess  [Trigger.oldMap access]
+    */
+    public StaffAccessHandler(List<Staff_Access__c> access, Map<Id, Staff_Access__c> oldAccess) {
+        this.access = access;
+        this.oldAccess = oldAccess;
+    }
+
+    /**
+     * @description Stamps the staff id on the record for duplicate rule
+     */
+    public void stampStaffIdOnRecord(){
+        if(!Schema.SObjectType.AccountShare.isCreateable()) {
+            throw new AuraHandledException('User has no permission to perform this action');
+        }
+
+        for(Staff_Access__c thisAssignment : access){
+            thisAssignment.Staff_Record_ID__c = thisAssignment.Staff__c;
+        }
+    }
+}

--- a/force-app/main/default/classes/StaffAccessHandler.cls-meta.xml
+++ b/force-app/main/default/classes/StaffAccessHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/StaffAccessHandlerTest.cls
+++ b/force-app/main/default/classes/StaffAccessHandlerTest.cls
@@ -1,0 +1,69 @@
+/*
+    Copyright (c) 2020, Traction Sales And Marketing Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this List of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this List of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author  Heather Purvis, Traction on Demand
+ * @date    2020-05-13
+ */
+@IsTest
+private class StaffAccessHandlerTest {
+
+    private final static String HA_ACCOUNT_NAME = 'Test SAHT Health Auth';
+    private final static String HOSP_ACCOUNT_NAME = 'Test SAHT hospital';
+    private final static String HOSP_CONTACT_NAME = 'Test SAHT Hosp contact';
+
+    @TestSetup
+    static void testSetup() {
+        Account healthAuth = TestUtils.createAccountByRecordType(HA_ACCOUNT_NAME, Constants.HEALTH_AUTH_RECORDTYPE_ID, null, TRUE);
+
+        Account hospital = TestUtils.createAccountByRecordType(HOSP_ACCOUNT_NAME, Constants.HOSPITAL_RECORDTYPE_ID, healthAuth.Id, FALSE);
+        hospital.Health_Authority__c = HA_ACCOUNT_NAME;
+        insert hospital;
+
+        Contact testContact = TestUtils.createCommunityContact(HOSP_CONTACT_NAME, FALSE);
+        testContact.AccountId = hospital.Id;
+        insert testContact;
+    }
+
+    @IsTest
+    static void stampStaffIdOnFacility() {
+        Account hospital = [SELECT Id, Name FROM Account WHERE RecordTypeId = :Constants.HOSPITAL_RECORDTYPE_ID AND Name = :HOSP_ACCOUNT_NAME];
+        Contact testContact = [SELECT Id, Name FROM Contact WHERE AccountId = :hospital.Id LIMIT 1];
+
+        Staff_Access__c testAccess = TestUtils.createReadStaffAccess(testContact.Id, hospital.Id, false);
+
+        Test.startTest();
+        insert testAccess;
+        Test.stopTest();
+
+        testAccess = [SELECT Id, Staff_Record_ID__c, Staff__c FROM Staff_Access__c WHERE Id = :testAccess.Id];
+
+        System.assertEquals(testAccess.Staff__c, testAccess.Staff_Record_ID__c, 'Expected Id to be stamped correctly in field');
+    }
+}

--- a/force-app/main/default/classes/StaffAccessHandlerTest.cls-meta.xml
+++ b/force-app/main/default/classes/StaffAccessHandlerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/StaffAccessService.cls
+++ b/force-app/main/default/classes/StaffAccessService.cls
@@ -1,0 +1,41 @@
+/*
+
+    Copyright (c) 2020, Traction Sales And Marketing Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this List of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this List of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * @author  Heather Purvis, Traction on Demand
+ * @date    2020-05-13
+ */
+public with sharing class StaffAccessService {
+
+    public void onBeforeInsert(List<SObject> records) {
+        StaffAccessHandler staffAccessHandler = new StaffAccessHandler((List<Staff_Access__c>) records, null);
+        staffAccessHandler.stampStaffIdOnRecord();
+    }
+}

--- a/force-app/main/default/classes/StaffAccessService.cls-meta.xml
+++ b/force-app/main/default/classes/StaffAccessService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/TestUtils.cls
+++ b/force-app/main/default/classes/TestUtils.cls
@@ -191,11 +191,41 @@ public class TestUtils {
         insert setting;
     }
 
-    public static Staff_Access__c createStaffAccess(Id contactId, Id careFacilityId, Boolean doInsert) {
+    public static Staff_Access__c createStaffAccess(Id contactId, Id facilityId, Boolean doInsert) {
         Staff_Access__c result = new Staff_Access__c(
                 Name = 'N/A',
                 Staff__c = contactId,
-                Care_Facility__c = careFacilityId
+                Care_Facility__c = facilityId
+        );
+
+        if(doInsert){
+            insert result;
+        }
+
+        return result;
+    }
+
+    public static Staff_Access__c createReadStaffAccess(Id contactId, Id facilityId, Boolean doInsert) {
+        Staff_Access__c result = new Staff_Access__c(
+                Name = 'N/A',
+                Staff__c = contactId,
+                Care_Facility__c = facilityId,
+                Access_Level__c = Constants.READ_ACCESS
+        );
+
+        if(doInsert){
+            insert result;
+        }
+
+        return result;
+    }
+
+    public static Staff_Access__c createEditStaffAccess(Id contactId, Id facilityId, Boolean doInsert) {
+        Staff_Access__c result = new Staff_Access__c(
+                Name = 'N/A',
+                Staff__c = contactId,
+                Care_Facility__c = facilityId,
+                Access_Level__c = Constants.EDIT_ACCESS
         );
 
         if(doInsert){

--- a/force-app/main/default/triggers/StaffAccessTrigger.trigger
+++ b/force-app/main/default/triggers/StaffAccessTrigger.trigger
@@ -1,0 +1,42 @@
+/*
+    Copyright (c) 2020, Traction Sales And Marketing Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this List of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this List of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Salesforce.org nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+/**
+ * @author  Heather Purvis, Traction on Demand
+ * @date    2020-05-13
+ */
+trigger StaffAccessTrigger on Staff_Access__c (before insert, before update, before delete, after insert, after update, after delete, after undelete) {
+    StaffAccessService staffAccessService = new StaffAccessService();
+
+    if (Trigger.isBefore) {
+        if (Trigger.isInsert) {
+            staffAccessService.onBeforeInsert(Trigger.new);
+        }
+    }
+}

--- a/force-app/main/default/triggers/StaffAccessTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/StaffAccessTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
# Critical Changes

# Changes
- Stamp staff id on staff access record - used to calculated duplicate records

# Issues Closed
