### PR TITLE
R1.9 TRACTION-431 | Validation Rule | Care facility creation reinforces hierarchy structure

### DIFF
--- a/force-app/main/default/classes/AccountsSelectorTest.cls
+++ b/force-app/main/default/classes/AccountsSelectorTest.cls
@@ -77,6 +77,8 @@ public with sharing class AccountsSelectorTest {
 
 	@IsTest
 	static void getAccountByRecordType() {
+		contact = [SELECT Id FROM Contact];
+		communityUser = [SELECT Id FROM User WHERE ContactId =:contact.Id];
 		System.runAs(communityUser) {
 			List<Account> accounts = AccountsSelector.getAccountByRecordType(Constants.HOSPITAL_RECORDTYPE_ID);
 			System.assert(accounts.size() > 0);
@@ -85,6 +87,8 @@ public with sharing class AccountsSelectorTest {
 
 	@IsTest
 	static void getChildAccountsByParent() {
+		contact = [SELECT Id FROM Contact];
+		communityUser = [SELECT Id FROM User WHERE ContactId =:contact.Id];
 		healthAuth = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.HEALTH_AUTH_RECORDTYPE_ID];
 		hospital = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.HOSPITAL_RECORDTYPE_ID];
 
@@ -98,6 +102,8 @@ public with sharing class AccountsSelectorTest {
 	@IsTest
 	static void getHospitalsByAuthorityName() {
 		healthAuth = [SELECT Id, Name FROM Account WHERE RecordTypeId = :Constants.HEALTH_AUTH_RECORDTYPE_ID];
+		contact = [SELECT Id FROM Contact];
+		communityUser = [SELECT Id FROM User WHERE ContactId =:contact.Id];
 
 		System.runAs(communityUser) {
 			List<Account> accounts = AccountsSelector.getHospitalsByAuthorityName(healthAuth.Name);
@@ -107,6 +113,8 @@ public with sharing class AccountsSelectorTest {
 
 	@IsTest
 	static void getDivisionTree() {
+		contact = [SELECT Id FROM Contact];
+		communityUser = [SELECT Id FROM User WHERE ContactId =:contact.Id];
 		System.runAs(communityUser) {
 			List<Account> accounts = AccountsSelector.getDivisionTree();
 			System.assert(accounts.size() > 0);
@@ -118,6 +126,8 @@ public with sharing class AccountsSelectorTest {
 		healthAuth = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.HEALTH_AUTH_RECORDTYPE_ID];
 		hospital = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.HOSPITAL_RECORDTYPE_ID];
 		divisionAccount = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.DIVISION_RECORDTYPE_ID];
+		contact = [SELECT Id FROM Contact];
+		communityUser = [SELECT Id FROM User WHERE ContactId =:contact.Id];
 
 		System.runAs(communityUser) {
 			List<Account> accounts = AccountsSelector.getAccount(new Set<Id>{

--- a/force-app/main/default/classes/AccountsSelectorTest.cls
+++ b/force-app/main/default/classes/AccountsSelectorTest.cls
@@ -34,33 +34,33 @@
  */
 @IsTest
 public with sharing class AccountsSelectorTest {
-	static Account account;
+	static Account healthAuth;
+	static Account hospital;
+	static Account divisionAccount;
 	static Contact contact;
 	static User communityUser;
-	static Account childAccount;
-	static Account divisionAccount;
 
 	@TestSetup
 	static void prepareData() {
 
-		account = TestUtils.createCommunityAccount('A BC Hospital for Testing Use Only', true);
+		healthAuth = TestUtils.createAccountByRecordType('A BC Health Auth for Testing Use Only', Constants.HEALTH_AUTH_RECORDTYPE_ID, null, true);
 		contact = TestUtils.createCommunityContact('Watson-Testing', false);
-		contact.AccountId = account.Id;
+		contact.AccountId = healthAuth.Id;
 		insert contact;
 
-		childAccount = new Account(
+		hospital = new Account(
 				Name = 'Child Account',
-				ParentId = account.Id,
+				ParentId = healthAuth.Id,
 				RecordTypeId = Constants.HOSPITAL_RECORDTYPE_ID,
 				BillingState = 'BC',
 				Health_Authority__c = 'Division Test'
 		);
 
-		insert childAccount;
+		insert hospital;
 
 		divisionAccount = new Account(
 				Name = 'Division Account',
-				ParentId = account.Id,
+				ParentId = hospital.Id,
 				RecordTypeId = Constants.DIVISION_RECORDTYPE_ID,
 				BillingState = 'BC',
 				Health_Authority__c = 'Division Test'
@@ -77,7 +77,6 @@ public with sharing class AccountsSelectorTest {
 
 	@IsTest
 	static void getAccountByRecordType() {
-		prepareData();
 		System.runAs(communityUser) {
 			List<Account> accounts = AccountsSelector.getAccountByRecordType(Constants.HOSPITAL_RECORDTYPE_ID);
 			System.assert(accounts.size() > 0);
@@ -86,26 +85,28 @@ public with sharing class AccountsSelectorTest {
 
 	@IsTest
 	static void getChildAccountsByParent() {
-		prepareData();
+		healthAuth = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.HEALTH_AUTH_RECORDTYPE_ID];
+		hospital = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.HOSPITAL_RECORDTYPE_ID];
+
 		System.runAs(communityUser) {
-			List<Account> accounts = AccountsSelector.getChildAccountsByParent(account.Id);
-			System.assert(accounts.size() == 2);
-			System.assertEquals(childAccount.Id, accounts[0].Id);
+			List<Account> accounts = AccountsSelector.getChildAccountsByParent(healthAuth.Id);
+			System.assertEquals(1, accounts.size());
+			System.assertEquals(hospital.Id, accounts[0].Id);
 		}
 	}
 
 	@IsTest
 	static void getHospitalsByAuthorityName() {
-		prepareData();
+		healthAuth = [SELECT Id, Name FROM Account WHERE RecordTypeId = :Constants.HEALTH_AUTH_RECORDTYPE_ID];
+
 		System.runAs(communityUser) {
-			List<Account> accounts = AccountsSelector.getHospitalsByAuthorityName(account.Name);
+			List<Account> accounts = AccountsSelector.getHospitalsByAuthorityName(healthAuth.Name);
 			System.assert(accounts.size() > 0);
 		}
 	}
 
 	@IsTest
 	static void getDivisionTree() {
-		prepareData();
 		System.runAs(communityUser) {
 			List<Account> accounts = AccountsSelector.getDivisionTree();
 			System.assert(accounts.size() > 0);
@@ -114,9 +115,13 @@ public with sharing class AccountsSelectorTest {
 
 	@IsTest
 	static void getAccount() {
-		prepareData();
+		healthAuth = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.HEALTH_AUTH_RECORDTYPE_ID];
+		hospital = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.HOSPITAL_RECORDTYPE_ID];
+		divisionAccount = [SELECT Id FROM Account WHERE RecordTypeId = :Constants.DIVISION_RECORDTYPE_ID];
+
 		System.runAs(communityUser) {
-			List<Account> accounts = AccountsSelector.getAccount(new Set<Id>{account.Id, childAccount.Id, divisionAccount.Id});
+			List<Account> accounts = AccountsSelector.getAccount(new Set<Id>{
+					healthAuth.Id, hospital.Id, divisionAccount.Id});
 			System.assert(accounts.size() == 3);
 		}
 	}

--- a/force-app/main/default/objects/Account/validationRules/Block_edits_to_Parent_Facility.validationRule-meta.xml
+++ b/force-app/main/default/objects/Account/validationRules/Block_edits_to_Parent_Facility.validationRule-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Block_edits_to_Parent_Facility</fullName>
+    <active>true</active>
+    <description>Blocks users from editing the Parent Facility field.</description>
+    <errorConditionFormula>!ISBLANK( PRIORVALUE( ParentId ) ) &amp;&amp;
+ISCHANGED( ParentId )</errorConditionFormula>
+    <errorDisplayField>ParentId</errorDisplayField>
+    <errorMessage>Unable to edit an existing Parent Facility. Please edit the values of the Parent Facility record itself.</errorMessage>
+</ValidationRule>

--- a/force-app/main/default/objects/Account/validationRules/Only_Health_Auths_can_parent_Hospitals.validationRule-meta.xml
+++ b/force-app/main/default/objects/Account/validationRules/Only_Health_Auths_can_parent_Hospitals.validationRule-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Only_Health_Auths_can_parent_Hospitals</fullName>
+    <active>true</active>
+    <description>Ensures that only Regional Health Authority Facilities can be a parent of Hospital Facilities.</description>
+    <errorConditionFormula>CONTAINS( RecordType.DeveloperName, &quot;Hospital&quot; ) &amp;&amp;
+!( ISBLANK( ParentId ) || ISNULL( ParentId) ) &amp;&amp;
+!CONTAINS( Parent.RecordType.DeveloperName, &quot;Regional_Health_Authority&quot; )</errorConditionFormula>
+    <errorDisplayField>ParentId</errorDisplayField>
+    <errorMessage>Invalid Parent Facility. Only Regional Health Authorities can be a parent of Hospitals.</errorMessage>
+</ValidationRule>

--- a/force-app/main/default/objects/Account/validationRules/Only_Hospitals_can_parent_Divisions.validationRule-meta.xml
+++ b/force-app/main/default/objects/Account/validationRules/Only_Hospitals_can_parent_Divisions.validationRule-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Only_Hospitals_can_parent_Divisions</fullName>
+    <active>true</active>
+    <description>Ensures that only Hospital Facilities can be a parent to a Division Facility.</description>
+    <errorConditionFormula>CONTAINS( RecordType.DeveloperName, &quot;Division&quot; ) &amp;&amp;
+!( ISBLANK( ParentId ) || ISNULL( ParentId ) ) &amp;&amp;
+!CONTAINS( Parent.RecordType.DeveloperName, &quot;Hospital&quot; )</errorConditionFormula>
+    <errorDisplayField>ParentId</errorDisplayField>
+    <errorMessage>Invalid Parent Facility. Only Hospitals can be a parent of Divisions.</errorMessage>
+</ValidationRule>


### PR DESCRIPTION

# Critical Changes

# Changes
- Created the following Account Validation Rules:
-- Only Hospitals can parent Divisions
-- Only Health Authorities can parent Hospitals
-- Block edits to Parent Facility

# Issues Closed
