### PR TITLE
R1.9 TRACTION-433 | WorkFlow | Remove workflow to stamp health auth name field

### DIFF
--- a/force-app/main/default/workflows/Account.workflow-meta.xml
+++ b/force-app/main/default/workflows/Account.workflow-meta.xml
@@ -18,13 +18,13 @@ IF(RecordType.DeveloperName == &#39;Regional_Health_Authority&#39;, Name, &#39;&
         <reevaluateOnChange>true</reevaluateOnChange>
     </fieldUpdates>
     <rules>
-        <fullName>Stamp Health Authority</fullName>
+        <fullName>%28DEPR%29 Stamp Health Authority</fullName>
         <actions>
             <name>Stamp_Health_Authority</name>
             <type>FieldUpdate</type>
         </actions>
-        <active>true</active>
-        <description>To facilitate sharing from department to health authority level, stamp the Health Authority name on the department records.</description>
+        <active>false</active>
+        <description>(DEPR) To facilitate sharing from department to health authority level, stamp the Health Authority name on the department records. This functionality has been replaced by a trigger.</description>
         <formula>ISBLANK (Health_Authority__c)</formula>
         <triggerType>onAllChanges</triggerType>
     </rules>


### PR DESCRIPTION

# Critical Changes

# Changes
- Deactivated the Workflow Rule: Stamp Health Authority.

# Issues Closed
