### PR TITLE
fix: Staff Access and Credentials Related lists are not visible

### DIFF
--- a/unpackaged/config/community/experiences/Traction_Thrive1/views/staffDetail.json
+++ b/unpackaged/config/community/experiences/Traction_Thrive1/views/staffDetail.json
@@ -36,7 +36,7 @@
       "type" : "component"
     }, {
       "componentAttributes" : {
-        "relatedListApiName" : "Credentials__r",
+        "relatedListApiName" : "%%%NAMESPACE%%%Credentials__r",
         "relatedListComponentOverride" : "GRID",
         "width" : "MEDIUM"
       },
@@ -47,7 +47,7 @@
       "type" : "component"
     }, {
       "componentAttributes" : {
-        "relatedListApiName" : "StaffAccess__r",
+        "relatedListApiName" : "%%%NAMESPACE%%%StaffAccess__r",
         "relatedListComponentOverride" : "GRID",
         "width" : "MEDIUM"
       },


### PR DESCRIPTION
fix: Staff Access and Credentials related lists on Staff Detail page were not visible in namespaced community

Closes traction-440

# Critical Changes

# Changes

# Issues Closed
